### PR TITLE
Force outer Yocto check if inner one has changed

### DIFF
--- a/meta/classes/build_yocto.bbclass
+++ b/meta/classes/build_yocto.bbclass
@@ -89,6 +89,10 @@ python do_configure() {
             bb.build.exec_func("build_yocto_add_bblayer", d)
 }
 
+# force running inner build's bitbake to check if anythyng has changed:
+# this is needed as upper Yocto only sees changes in its own recipes,
+# but inner Yocto is not checked
+do_compile[nostamp] = "1"
 do_compile() {
     cd ${S}
     source poky/oe-init-build-env


### PR DESCRIPTION
Force running inner build's bitbake to check if anythyng has changed:
this is needed as upper Yocto only sees changes in its own recipes,
but inner Yocto is not checked

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>