### PR TITLE
Fix: do not force ROOTFS location for Yocto builds

### DIFF
--- a/meta/classes/build_yocto.bbclass
+++ b/meta/classes/build_yocto.bbclass
@@ -45,9 +45,6 @@ build_yocto_configure() {
         if [ -n ${SSTATE_DIR} ] ; then
                 base_update_conf_value ${local_conf} SSTATE_DIR ${SSTATE_DIR}/${PN}
         fi
-        if [ -n ${IMAGE_ROOTFS} ] ; then
-                base_update_conf_value ${local_conf} IMAGE_ROOTFS ${IMAGE_ROOTFS}/${PN}
-        fi
         if [ -n ${DEPLOY_DIR} ] ; then
                 base_update_conf_value ${local_conf} DEPLOY_DIR ${DEPLOY_DIR}/${PN}
         fi

--- a/meta/conf/local.conf.sample
+++ b/meta/conf/local.conf.sample
@@ -235,8 +235,7 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "1"
 
 DEPLOY_DIR = "${TMPDIR}/deploy"
-IMAGE_ROOTFS = "${TMPDIR}/rootfs"
-XT_SHARED_ROOTFS_DIR = "${IMAGE_ROOTFS}/shared_rootfs"
+XT_SHARED_ROOTFS_DIR = "${TMPDIR}/shared_rootfs"
 BUILDHISTORY_DIR = "${TMPDIR}/buildhistory"
 
 #


### PR DESCRIPTION
There is no value in having built rootfs at some
predefined location. What is more, when multiple
images are built by the inner Yocto it makes
it impossible to do so because of rootfs clashes.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>