### PR TITLE
Add environment variable to enable/disable populating sstate-cache

### DIFF
--- a/README
+++ b/README
@@ -36,6 +36,10 @@ usage for inner builds: this will set SSTATE_CACHE_MIRROR in corresponding
 local.conf file(s).
 N.B. This must not be used if build history is needs to be provided.
 
+XT_POPULATE_SSTATE_CACHE - if set then every domain build will be requested to
+populate its build cache (sstate, ccache), e.g. if there are two images are
+built (Dom0 and DomU), then both will be asked to populate corresponding caches.
+
 XT_POPULATE_SDK – if set then every domain build will be requested to populate
 SDK, e.g. if there are two images are built (Dom0 and DomU), then both will be
 asked to populate corresponding SDKs.

--- a/meta/classes/build_yocto.bbclass
+++ b/meta/classes/build_yocto.bbclass
@@ -21,6 +21,7 @@ EXPANDED_XT_SHARED_ROOTFS_DIR = "${@d.getVar('XT_SHARED_ROOTFS_DIR') or ''}"
 EXPANDED_XT_SSTATE_CACHE_MIRROR_DIR = "${@d.getVar('XT_SSTATE_CACHE_MIRROR_DIR') or ''}"
 EXPANDED_XT_ALLOW_SSTATE_CACHE_MIRROR_USE = "${@d.getVar('XT_ALLOW_SSTATE_CACHE_MIRROR_USE') or ''}"
 EXPANDED_XT_POPULATE_SDK = "${@d.getVar('XT_POPULATE_SDK') or ''}"
+EXPANDED_XT_POPULATE_SSTATE_CACHE = "${@d.getVar('XT_POPULATE_SSTATE_CACHE') or ''}"
 
 REAL_XT_BB_CONFIG_CMD = "${@d.getVar('XT_BB_CONFIG_CMD') or 'source poky/oe-init-build-env'}"
 REAL_XT_BB_RUN_CMD = "${@d.getVar('XT_BB_RUN_CMD') or 'source poky/oe-init-build-env'}"
@@ -126,9 +127,11 @@ do_collect_build_history() {
 }
 
 do_populate_sstate_cache() {
-    if [ -n "${EXPANDED_XT_SSTATE_CACHE_MIRROR_DIR}" ] ; then
-        install -d "${XT_SSTATE_CACHE_MIRROR_DIR}"
-        cp -a "${SSTATE_DIR}/${PN}/." "${XT_SSTATE_CACHE_MIRROR_DIR}/" || true
+    if [ -n "${EXPANDED_XT_POPULATE_SSTATE_CACHE}" ] ; then
+        if [ -n "${EXPANDED_XT_SSTATE_CACHE_MIRROR_DIR}" ] ; then
+            install -d "${XT_SSTATE_CACHE_MIRROR_DIR}"
+            cp -a "${SSTATE_DIR}/${PN}/." "${XT_SSTATE_CACHE_MIRROR_DIR}/" || true
+        fi
     fi
 }
 


### PR DESCRIPTION
Introduce XT_POPULATE_SSTATE_CACHE variable for controlling if
domain builds will be requested to populate their build caches,
e.g. sstate, ccache.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>