### PR TITLE
Make pack/unpack multithreaded

### DIFF
--- a/bitbake/lib/bb/fetch2/__init__.py
+++ b/bitbake/lib/bb/fetch2/__init__.py
@@ -1398,7 +1398,7 @@ class FetchMethod(object):
 
         if unpack:
             if file.endswith('.tar'):
-                cmd = 'tar x --no-same-owner -f %s' % file
+                cmd = 'unpigz < %s | tar x --no-same-owner' % file
             elif file.endswith('.tgz') or file.endswith('.tar.gz') or file.endswith('.tar.Z'):
                 cmd = 'tar xz --no-same-owner -f %s' % file
             elif file.endswith('.tbz') or file.endswith('.tbz2') or file.endswith('.tar.bz2'):

--- a/bitbake/lib/bb/fetch2/repo.py
+++ b/bitbake/lib/bb/fetch2/repo.py
@@ -82,7 +82,7 @@ class Repo(FetchMethod):
             tar_flags = "--exclude='.repo' --exclude='.git'"
 
         # Create a cache
-        runfetchcmd("tar %s -czf %s %s" % (tar_flags, ud.localpath, os.path.join(".", "*") ), d, workdir=ud.codir)
+        runfetchcmd("tar %s -cf - %s | pigz > %s" % (tar_flags, os.path.join(".", "*"), ud.localpath), d, workdir=ud.codir)
 
     def unpack(self, ud, destdir, d):
         FetchMethod.unpack(self, ud, destdir, d)


### PR DESCRIPTION
Use pigz/unpigz to make fetcher's pack/unpack tar
run in parallel.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Artem Mygaiev <artem_mygaiev@epam.com>