### PR TITLE
Some enhancements and fixes

### DIFF
--- a/meta/classes/base.bbclass
+++ b/meta/classes/base.bbclass
@@ -76,15 +76,35 @@ base_update_conf_value() {
     local config_file=$1
     local key=$2
     local value=$3
-    local key_prefix=$4
     local exists=`grep "^[^\#]*${key}.*=" "${config_file}"`
 
     if [ -z "${exists}" ] ; then
         # make placeholder
-        echo "${key}${key_prefix}=" >> "${config_file}"
+        echo "${key} = " >> "${config_file}"
     fi
     # substitute
     sed -i "s%\(^${key} *[?+:]*= *\).*%\1\"${value}\"%" "${config_file}"
+}
+
+base_adjust_conf_value() {
+    local config_file=$1
+    local key=$2
+    local value=$3
+    local adjustment=$4
+
+    echo "${key} ${adjustment} "\"${value}\" >> "${config_file}"
+}
+
+base_set_conf_value() {
+   base_adjust_conf_value $1 $2 $3 "="
+}
+
+base_add_conf_value() {
+    base_adjust_conf_value $1 $2 $3 "+="
+}
+
+base_remove_conf_value() {
+    base_adjust_conf_value $1 $2 $3 "-="
 }
 
 addtask fetch

--- a/meta/classes/build_yocto.bbclass
+++ b/meta/classes/build_yocto.bbclass
@@ -81,7 +81,7 @@ build_yocto_configure() {
                         echo "SSTATE_MIRRORS=\"file://.* file://${XT_SSTATE_CACHE_MIRROR_DIR}/PATH\"" >> "${local_conf}"
                 fi
         fi
-        base_update_conf_value "${local_conf}" INHERIT buildhistory "+"
+        base_add_conf_value "${local_conf}" INHERIT buildhistory
         base_update_conf_value "${local_conf}" BUILDHISTORY_COMMIT 1
     fi
 }


### PR DESCRIPTION
Add base_set_conf_value function in case we need multiple same
variables in file. Unlike shell scripts "=" should be whitespace
surrounded so fix it.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>