### PR TITLE
Add additional machine overrides to tell Salvator H3 SoC versions

### DIFF
--- a/meta/conf/machine/salvator-x-h3-4x2g.conf
+++ b/meta/conf/machine/salvator-x-h3-4x2g.conf
@@ -1,3 +1,3 @@
 require xt-distro-machine.inc
 
-MACHINEOVERRIDES =. "rcar:rcar-gen3:"
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es3"

--- a/meta/conf/machine/salvator-x-h3.conf
+++ b/meta/conf/machine/salvator-x-h3.conf
@@ -1,3 +1,3 @@
 require xt-distro-machine.inc
 
-MACHINEOVERRIDES =. "rcar:rcar-gen3:"
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es2"


### PR DESCRIPTION
There are two versions of r8a7795 SoC available at the moment: v2.0
and v3.0. Add additional machine overrides to tell exact Salvator
H3 SoC versions, so this can be used in recipes.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>