### PR TITLE
Add Salvator-XS machines

### DIFF
--- a/meta/conf/machine/salvator-xs-h3-2x2g.conf
+++ b/meta/conf/machine/salvator-xs-h3-2x2g.conf
@@ -1,0 +1,3 @@
+require xt-distro-machine.inc
+
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es3"

--- a/meta/conf/machine/salvator-xs-h3-4x2g.conf
+++ b/meta/conf/machine/salvator-xs-h3-4x2g.conf
@@ -1,0 +1,3 @@
+require xt-distro-machine.inc
+
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es3"

--- a/meta/conf/machine/salvator-xs-h3.conf
+++ b/meta/conf/machine/salvator-xs-h3.conf
@@ -1,3 +1,3 @@
 require xt-distro-machine.inc
 
-MACHINEOVERRIDES =. "rcar:rcar-gen3:"
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es2"


### PR DESCRIPTION
Add Salvator-XS machines with H3 ES3.0 SIPs. Also specify explicitely
a SoC version for H3 ES2.0 based machine.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>