### PR TITLE
Extend MACHINEOVERRIDES for h3ulcb

### DIFF
--- a/meta/conf/machine/h3ulcb.conf
+++ b/meta/conf/machine/h3ulcb.conf
@@ -1,3 +1,3 @@
 require xt-distro-machine.inc
 
-MACHINEOVERRIDES =. "rcar:rcar-gen3:"
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7795-es2"


### PR DESCRIPTION
h3ulcb-xt (the first machine we are going to support) is based
on r8a7795-es2.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Reviewed-by: Andrii Anisov <andrii_anisov@epam.com>