### PR TITLE
Save repo manifest while collecting build history

### DIFF
--- a/meta/classes/build_yocto.bbclass
+++ b/meta/classes/build_yocto.bbclass
@@ -145,6 +145,13 @@ do_collect_build_history() {
     ${REAL_XT_BB_RUN_CMD}
     HISTORY_DIR="${BUILDHISTORY_DIR}/${PN}"
     buildhistory-collect-srcrevs -a -p "${HISTORY_DIR}" > "${HISTORY_DIR}/build-versions.inc"
+    # if this is a repo-based build then save the exact manifest used
+    # with all the revisions set to used commit IDs
+    # we are running in the build directory, repo is one level up
+    cd ..
+    if [ -d ".repo" ]; then
+        repo manifest --output-file="${HISTORY_DIR}/domain.xml"
+    fi
 }
 
 do_populate_sstate_cache() {


### PR DESCRIPTION
Meta layer revisions, collected during the build with build
history enabled, list all the meta layers used with their revisions.
This is not practical to use these as revisions are also listed
for meta layers which live inside other meta layers: for instance,
this is the case for meta-openembedded which will have something like

[snip]
meta-oe           = HEAD:dacfa2b1920e285531bec55cd2f08743390aaf57
meta-networking   = HEAD:dacfa2b1920e285531bec55cd2f08743390aaf57
[snip]

During build reconstruction this is not obvious and easy to tell
which is the primary meta layer to be checked out so its children
are fetched automatically.

For repo based builds we can utilize repo tool to generate the exact
manifest used for the build, so use it and save the manifest as a part
of build history.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>