### PR TITLE
Pass arguments to base_update_conf_value with quotes

### DIFF
--- a/meta/classes/base.bbclass
+++ b/meta/classes/base.bbclass
@@ -96,15 +96,15 @@ base_adjust_conf_value() {
 }
 
 base_set_conf_value() {
-   base_adjust_conf_value $1 $2 $3 "="
+   base_adjust_conf_value "$1" "$2" "$3" "="
 }
 
 base_add_conf_value() {
-    base_adjust_conf_value $1 $2 $3 "+="
+    base_adjust_conf_value "$1" "$2" "$3" "+="
 }
 
 base_remove_conf_value() {
-    base_adjust_conf_value $1 $2 $3 "-="
+    base_adjust_conf_value "$1" "$2" "$3" "-="
 }
 
 addtask fetch


### PR DESCRIPTION
Arguments may contain spaces and be empty strings which
may prevent base_update_conf_value from running correctly.
To fix that surround the arguments with quotes explicitly.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>