### PR TITLE
Multiple jobs to fetch

### DIFF
--- a/bitbake/lib/bb/fetch2/repo.py
+++ b/bitbake/lib/bb/fetch2/repo.py
@@ -57,6 +57,14 @@ class Repo(FetchMethod):
         ud.codir = os.path.join(repodir, gitsrcname, ud.manifest)
         ud.repodir = os.path.join(ud.codir, "repo")
 
+    def sync(self, destdir, d):
+        # repo can separate the "network" sync (the git fetch part, network bound)
+        # from the "local" sync (the git rebase part, compute & i/o bound).
+        num_jobs = d.getVar("BB_NUMBER_THREADS", True) or "1"
+        runfetchcmd("repo sync -c -n -j%s" % num_jobs, d, workdir=destdir)
+        runfetchcmd("repo sync -c -l -j%s" % num_jobs, d, workdir=destdir)
+
+
     def download(self, ud, d):
         """Fetch url"""
 
@@ -74,7 +82,7 @@ class Repo(FetchMethod):
         runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
 
         bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
-        runfetchcmd("repo sync", d, workdir=ud.repodir)
+        self.sync(ud.repodir, d)
 
         scmdata = ud.parm.get("scmdata", "")
         if scmdata == "keep":
@@ -88,7 +96,7 @@ class Repo(FetchMethod):
     def unpack(self, ud, destdir, d):
         FetchMethod.unpack(self, ud, destdir, d)
         bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
-        runfetchcmd("repo sync", d, workdir=ud.repodir)
+        self.sync(os.path.join(destdir, "repo"), d)
 
     def supports_srcrev(self):
         return False


### PR DESCRIPTION
Originally the patch
(0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch) was made
for the android to fetch the sources with the multiple jobs
The patch was merged into xt-distro to support the multiple fetch
at the high level.
Changes have been done in a file: repo.py

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>