### PR TITLE
Add Salvator-XS r8a7796 ES3.0+ with 8GiB (2 x 4 GiB) machine

### DIFF
--- a/meta/conf/machine/salvator-xs-m3-2x4g.conf
+++ b/meta/conf/machine/salvator-xs-m3-2x4g.conf
@@ -1,0 +1,3 @@
+require xt-distro-machine.inc
+
+MACHINEOVERRIDES =. "rcar:rcar-gen3:r8a7796-es3:"


### PR DESCRIPTION
Add Renesas Salvator-XS 2nd version board based on r8a7796 ES3.0+
with 8GiB (2 x 4 GiB) machine.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>