### PR TITLE
Print full error message

### DIFF
--- a/bitbake/lib/bb/build.py
+++ b/bitbake/lib/bb/build.py
@@ -80,8 +80,7 @@ class FuncFailed(Exception):
 
     def __str__(self):
         if self.logfile and os.path.exists(self.logfile):
-            msg = ("%s (log file is located at %s)" %
-                   (self.msg, self.logfile))
+            msg = open(self.logfile, 'r').read()
         else:
             msg = self.msg
         return msg


### PR DESCRIPTION
If an error occurs in the domain recipe, the message shows the file
location to that message. During the development process, it would
be better to have the complete output of the error.

Show complete message of the fatal error.

@andr2000
@lorc
@arminn 

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>