### PR TITLE
[for Rel-v7.0] Add support for Aosbox (H3ULCB ES3.0 8GB)

### DIFF
--- a/meta/conf/machine/h3ulcb-4x2g-ab.conf
+++ b/meta/conf/machine/h3ulcb-4x2g-ab.conf
@@ -1,0 +1,3 @@
+require h3ulcb-4x2g.conf
+
+MACHINEOVERRIDES =. "aosbox:"


### PR DESCRIPTION
Add support for H3ULCB AB ES3.0 8GB machine(CCPF Starter kit).

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>